### PR TITLE
Support rotary encoders using interrupts

### DIFF
--- a/debug_dref.py
+++ b/debug_dref.py
@@ -1,0 +1,9 @@
+import socket
+UDP_IP = "0.0.0.0"
+UDP_PORT = 49000
+sock = socket.socket(socket.AF_INET, # Internet
+                  socket.SOCK_DGRAM) # UDP
+sock.bind((UDP_IP, UDP_PORT))
+while True:
+    data, addr = sock.recvfrom(4096)
+    print("received message:", data)

--- a/example/Sample0/src/RomgereCockpit/ArduinoControl/ArduinoControl.h
+++ b/example/Sample0/src/RomgereCockpit/ArduinoControl/ArduinoControl.h
@@ -71,8 +71,8 @@ public:
   // Ici on va définir les méthode permettant de lire/ecrire les entrée Arduino
   // Permet de s'affranchir dans les classes de controles dérivée de la façon
   // dont ces actions sont faites (Par exemple pour une carte Esclave en I2C,
-  //cette méthode ne va pas appelée directement les fonction Arduino classique
-  //analogRead, analogWrite...)
+  // cette méthode ne va pas appelée directement les fonction Arduino classique
+  // analogRead, analogWrite...)
 
   // These methods are used to read/write on PIN with slave/master board
   // abstraction Direct call to arduino read/write for input/output on master

--- a/example/Sample0/src/RomgereCockpit/XPlaneCommand/XPlaneCommand.h
+++ b/example/Sample0/src/RomgereCockpit/XPlaneCommand/XPlaneCommand.h
@@ -117,8 +117,8 @@ class LibrarySpecialCommand : public XPlaneOutputCommand {
 
 public:
   typedef enum {
-    SendAll = 0, // Send all command of all (toggle switch and rotary switch)
-                 // input control even if control was not modified
+    SendAll = 0,  // Send all command of all (toggle switch and rotary switch)
+                  // input control even if control was not modified
     ResetArduino, // Reset Arduino board
     AllLedOn,     // Turn on all LED output controls (Example : testing panel)
     AllLedOff,    // Turn off all LED output controls

--- a/lib/Application/CockpitMainApplication.cpp
+++ b/lib/Application/CockpitMainApplication.cpp
@@ -194,7 +194,7 @@ void CockpitMainApplication::Loop() {
 #if NUMBER_LOOP_SKIP_FOR_READ_DATA_FROM_XPLANE > 1
   if (LoopNumber % NUMBER_LOOP_SKIP_FOR_READ_DATA_FROM_XPLANE == 0) {
 #endif
-
+/*
     // Read data from X-plane
     uint8_t nbDataRead = CommunicationInterface->ReadAllInput();
 
@@ -204,6 +204,7 @@ void CockpitMainApplication::Loop() {
         this->updateControlWithCommand(OutputControlList[i]);
       }
     }
+*/
 #if NUMBER_LOOP_SKIP_FOR_READ_DATA_FROM_XPLANE > 1
   }
 #endif

--- a/lib/Application/CockpitMainApplication.h
+++ b/lib/Application/CockpitMainApplication.h
@@ -7,7 +7,11 @@
 #define ROMGERECOCKPITCLASS_H_INCLUDED
 
 #include <Arduino.h>
+#ifndef USE_ENC28J60_ETHERNET_MODULE
+#include <EthernetENC.h>
+#else
 #include <Ethernet.h>
+#endif
 #include <SPI.h>
 
 #include "../Config/MainConfig.h"

--- a/lib/ArduinoControl/AllControlInclude.h
+++ b/lib/ArduinoControl/AllControlInclude.h
@@ -7,12 +7,13 @@
 // File allowing inclusion for all existing input/output controls types //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "ArduinoIncrementalThreePosToggleSwitchControl.h"
-#include "ArduinoLEDControl.h"
-#include "ArduinoPotentiometerControl.h"
 #include "ArduinoPushButtonControl.h"
+#include "ArduinoToggleSwitchControl.h"
+#include "ArduinoThreePosToggleSwitchControl.h"
+#include "ArduinoIncrementalThreePosToggleSwitchControl.h"
 #include "ArduinoRotaryEncoderControl.h"
 #include "ArduinoRotarySwitchControl.h"
+#include "ArduinoLEDControl.h"
 #include "ArduinoServoControl.h"
-#include "ArduinoThreePosToggleSwitchControl.h"
-#include "ArduinoToggleSwitchControl.h"
+#include "ArduinoPotentiometerControl.h"
+#include "ArduinoRotaryEncoderInterruptControl.h"

--- a/lib/ArduinoControl/AllControlInclude.h
+++ b/lib/ArduinoControl/AllControlInclude.h
@@ -7,13 +7,13 @@
 // File allowing inclusion for all existing input/output controls types //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "ArduinoPushButtonControl.h"
-#include "ArduinoToggleSwitchControl.h"
-#include "ArduinoThreePosToggleSwitchControl.h"
 #include "ArduinoIncrementalThreePosToggleSwitchControl.h"
-#include "ArduinoRotaryEncoderControl.h"
-#include "ArduinoRotarySwitchControl.h"
 #include "ArduinoLEDControl.h"
-#include "ArduinoServoControl.h"
 #include "ArduinoPotentiometerControl.h"
+#include "ArduinoPushButtonControl.h"
+#include "ArduinoRotaryEncoderControl.h"
 #include "ArduinoRotaryEncoderInterruptControl.h"
+#include "ArduinoRotarySwitchControl.h"
+#include "ArduinoServoControl.h"
+#include "ArduinoThreePosToggleSwitchControl.h"
+#include "ArduinoToggleSwitchControl.h"

--- a/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.cpp
+++ b/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.cpp
@@ -3,127 +3,118 @@
  * @author jerome@mestres.fr
  */
 
-
 #include "ArduinoRotaryEncoderInterruptControl.h"
 
-/*
-
-Source : http://svglobe.com/arduino/encoders.html
-
-
-dir. / ret :    <==(-1)==    ==(+1)==>
-           |-------------------------------|
-    Bit2   | 1 | 1 | 0 | 0 | 1 | 1 | 0 | 0 |
-    Bit1   | 0 | 1 | 1 | 0 | 0 | 1 | 1 | 0 |
-           |-------------------------------|
-    Val    | 2 | 3 | 1 | 0 | 2 | 3 | 1 | 0 |
-           |-------------------------------|
-Detent :
-Type1 Enc : ╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_
-Type2 Enc : ╔═╗_____╔═╗_____╔═╗_____╔═╗_____
-Type3 Enc : ____╔═╗_____╔═╗_____╔═╗_____╔═╗_
-Type4 Enc : ____________╔═╗_____________╔═╗_
-                         ▲
-                         ║
-
-For all types of rotary encoder, the direction logic is the same. Only detents vary.
-Command are send only if rotary is stop on a detent.
-*/
-
 #ifdef ACTIVE_MULTI_ARDUINO_BOARD_MODE
-ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl(  uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false, int boardAddress = -1) : ArduinoInputControl( DigitalControl, ITypeRotaryEncode, (boardAddress != -1), boardAddress){
+ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl(
+    uint8_t encoderNumber, uint8_t pin1, uint8_t pin2,
+    uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false,
+    int boardAddress = -1)
+    : ArduinoInputControl(DigitalControl, ITypeRotaryEncode,
+                          (boardAddress != -1), boardAddress) {
 #else
-ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false) : ArduinoInputControl( DigitalControl, ITypeRotaryEncode){
+ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl(
+    uint8_t encoderNumber, uint8_t pin1, uint8_t pin2,
+    uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false)
+    : ArduinoInputControl(DigitalControl, ITypeRotaryEncode) {
 #endif
 
-    this->encoderNumber = encoderNumber;
-    this->Pin1 = pin1;
-    this->Pin2 = pin2;
-    this->maxValue = (resolution_ppr * turns) / 2;
+  this->encoderNumber = encoderNumber;
+  this->Pin1 = pin1;
+  this->Pin2 = pin2;
+  this->maxValue = ((int)resolution_ppr * (int)turns);
+
+  pinMode(pin1, usePullUpPin ? INPUT_PULLUP : INPUT);
+  pinMode(pin2, usePullUpPin ? INPUT_PULLUP : INPUT);
+
+  this->currentValue = this->maxValue / 2;
+  this->lastUpStatus = -1;
+  this->isStatusChanged = true;
+
+  switch (encoderNumber) {
+  case 0:
     ArduinoRotaryEncoderInterruptControl::instance0_ = this;
-
-    pinMode(pin1, usePullUpPin? INPUT_PULLUP : INPUT);
-    pinMode(pin2, usePullUpPin? INPUT_PULLUP : INPUT);
-
-    this->currentValue = 0; 
-    this->lastUpStatus = -1;
-    this->isStatusChanged = true;
-  
-    attachInterrupt(digitalPinToInterrupt(this->Pin1), handleInterruptEncoder0, CHANGE);
-    attachInterrupt(digitalPinToInterrupt(this->Pin2), handleInterruptEncoder0, CHANGE);
-
- /*
-  attachInterrupt(digitalPinToInterrupt(this->Pin1), throttleLoop, CHANGE);
-  attachInterrupt(digitalPinToInterrupt(this->Pin2), throttleLoop, CHANGE);*/
+    attachInterrupt(digitalPinToInterrupt(this->Pin1), handleInterruptEncoder0,
+                    CHANGE);
+    attachInterrupt(digitalPinToInterrupt(this->Pin2), handleInterruptEncoder0,
+                    CHANGE);
+    break;
+  case 1:
+    ArduinoRotaryEncoderInterruptControl::instance1_ = this;
+    attachInterrupt(digitalPinToInterrupt(this->Pin1), handleInterruptEncoder1,
+                    CHANGE);
+    attachInterrupt(digitalPinToInterrupt(this->Pin2), handleInterruptEncoder1,
+                    CHANGE);
+    break;
+  }
 }
 
-
-ArduinoRotaryEncoderInterruptControl::~ArduinoRotaryEncoderInterruptControl(){}
+ArduinoRotaryEncoderInterruptControl::~ArduinoRotaryEncoderInterruptControl() {}
 
 // ISR glue routines
-void ArduinoRotaryEncoderInterruptControl::handleInterruptEncoder0 ()
-{
-  instance0_->handleInterrupt ();
+void ArduinoRotaryEncoderInterruptControl::handleInterruptEncoder0() {
+  instance0_->handleInterrupt();
+}
+
+void ArduinoRotaryEncoderInterruptControl::handleInterruptEncoder1() {
+  instance1_->handleInterrupt();
 }
 
 // for use by ISR glue routines
-ArduinoRotaryEncoderInterruptControl * ArduinoRotaryEncoderInterruptControl::instance0_;
+ArduinoRotaryEncoderInterruptControl
+    *ArduinoRotaryEncoderInterruptControl::instance0_;
+ArduinoRotaryEncoderInterruptControl
+    *ArduinoRotaryEncoderInterruptControl::instance1_;
 
+// class instance to handle interrupt
+void ArduinoRotaryEncoderInterruptControl::handleInterrupt() {
+  uint8_t newVal = 0;
+  newVal += _digitalRead(this->Pin1) == HIGH ? 1 : 0;
+  newVal += _digitalRead(this->Pin2) == HIGH ? 2 : 0;
 
-// class instance to handle an interrupt
-void ArduinoRotaryEncoderInterruptControl::handleInterrupt ()
-{
-  unsigned char encoderUp;
-  unsigned char encoderDn;
-
-  encoderUp = _digitalRead(this->Pin1) == HIGH ? 1 : 0;
-  encoderDn = _digitalRead(this->Pin2) == HIGH ? 2 : 0;
-
-  if( encoderUp != this->lastUpStatus ) {
-    if( encoderUp ) {
-    // rising edge
-      if ( encoderDn ) {
-        if( this->currentValue < this->maxValue ) this->currentValue ++;
-      } else {
-        if(this->currentValue > -this->maxValue ) this->currentValue --;
-      }
-    } else {
-    // falling edge
-      if ( encoderDn ) {
-        if( this->currentValue > -this->maxValue ) this->currentValue --;
-      } else {
-        if( this->currentValue < this->maxValue ) this->currentValue ++;
-      }
+  if (newVal & 1 != this->lastUpStatus) {
+    switch (newVal) {
+    case 0: // falling edge + falling edge
+      if (this->currentValue < this->maxValue)
+        this->currentValue++;
+      break;
+    case 1: // rising edge + falling edge
+      if (this->currentValue > 0)
+        this->currentValue--;
+      ;
+      break;
+    case 2: // falling edge + rising edge
+      if (this->currentValue > 0)
+        this->currentValue--;
+      break;
+    case 3: // rising edge + rising edge
+      if (this->currentValue < this->maxValue)
+        this->currentValue++;
+      break;
     }
   }
-  if (this->currentValue > this->maxValue) this->currentValue = this->maxValue;
-  if (this->currentValue < -this->maxValue) this->currentValue = -this->maxValue;
-  this->lastUpStatus = encoderUp;
-  this->isStatusChanged = true;
-}
 
+  this->lastUpStatus = newVal & 1;
+  this->isStatusChanged =
+      true; // if the interrupt got triggered, something has changed
+}
 
 void ArduinoRotaryEncoderInterruptControl::setValue(int16_t value) {
   this->currentValue = value;
 }
 
-
-float ArduinoRotaryEncoderInterruptControl::getValue(){ //returns the current value
+float ArduinoRotaryEncoderInterruptControl::getValue() { // returns the current
+                                                         // value
   float extValue;
-  /*
-  Serial.print("currentValue : ");
-  Serial.println(this->currentValue);
-  Serial.print("extValue : ");
-  Serial.println(extValue);
-  */
-  extValue = ((float)this->currentValue/this->maxValue);
-
+  extValue = ((float)this->currentValue / this->maxValue);
   return extValue;
 }
 
-bool ArduinoRotaryEncoderInterruptControl::ReadInput(){ // returns true if there was a change since the last time it was called
+bool ArduinoRotaryEncoderInterruptControl::
+    ReadInput() { // returns true if there was a change since the last time it
+                  // was called
 
-   
+  /*
     Serial.print("Control Debug : Read ArduinoRotaryEncoderInterruptControl[");
     Serial.print(this->Pin1);
     Serial.print(",");
@@ -133,18 +124,11 @@ bool ArduinoRotaryEncoderInterruptControl::ReadInput(){ // returns true if there
     Serial.print(" Stat : ");
 
     Serial.println(this->currentValue);
+  */
 
-    // Serial.print(isStatusChanged ? "CHANGE !" : "NO CHANGE");
-    // Serial.print(", Value : ");
-    // Serial.print(this->LastPinStatus[ROTARY_ENC_OLD_STATUS_INDEX]);
-    // Serial.print(",");
-    // Serial.print(newVal);
-    // Serial.println(".");
-
-    if( this->isStatusChanged)
-    {
-      this->isStatusChanged = false;
-      return true;
-    }
-    return false;
+  if (this->isStatusChanged) {
+    this->isStatusChanged = false;
+    return true;
+  }
+  return false;
 }

--- a/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.cpp
+++ b/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.cpp
@@ -1,0 +1,150 @@
+/**
+ * Romgere Cockpit Library - https://github.com/romgere/romgere_cockpit
+ * @author jerome@mestres.fr
+ */
+
+
+#include "ArduinoRotaryEncoderInterruptControl.h"
+
+/*
+
+Source : http://svglobe.com/arduino/encoders.html
+
+
+dir. / ret :    <==(-1)==    ==(+1)==>
+           |-------------------------------|
+    Bit2   | 1 | 1 | 0 | 0 | 1 | 1 | 0 | 0 |
+    Bit1   | 0 | 1 | 1 | 0 | 0 | 1 | 1 | 0 |
+           |-------------------------------|
+    Val    | 2 | 3 | 1 | 0 | 2 | 3 | 1 | 0 |
+           |-------------------------------|
+Detent :
+Type1 Enc : ╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_╔═╗_
+Type2 Enc : ╔═╗_____╔═╗_____╔═╗_____╔═╗_____
+Type3 Enc : ____╔═╗_____╔═╗_____╔═╗_____╔═╗_
+Type4 Enc : ____________╔═╗_____________╔═╗_
+                         ▲
+                         ║
+
+For all types of rotary encoder, the direction logic is the same. Only detents vary.
+Command are send only if rotary is stop on a detent.
+*/
+
+#ifdef ACTIVE_MULTI_ARDUINO_BOARD_MODE
+ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl(  uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false, int boardAddress = -1) : ArduinoInputControl( DigitalControl, ITypeRotaryEncode, (boardAddress != -1), boardAddress){
+#else
+ArduinoRotaryEncoderInterruptControl::ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false) : ArduinoInputControl( DigitalControl, ITypeRotaryEncode){
+#endif
+
+    this->encoderNumber = encoderNumber;
+    this->Pin1 = pin1;
+    this->Pin2 = pin2;
+    this->maxValue = (resolution_ppr * turns) / 2;
+    ArduinoRotaryEncoderInterruptControl::instance0_ = this;
+
+    pinMode(pin1, usePullUpPin? INPUT_PULLUP : INPUT);
+    pinMode(pin2, usePullUpPin? INPUT_PULLUP : INPUT);
+
+    this->currentValue = 0; 
+    this->lastUpStatus = -1;
+    this->isStatusChanged = true;
+  
+    attachInterrupt(digitalPinToInterrupt(this->Pin1), handleInterruptEncoder0, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(this->Pin2), handleInterruptEncoder0, CHANGE);
+
+ /*
+  attachInterrupt(digitalPinToInterrupt(this->Pin1), throttleLoop, CHANGE);
+  attachInterrupt(digitalPinToInterrupt(this->Pin2), throttleLoop, CHANGE);*/
+}
+
+
+ArduinoRotaryEncoderInterruptControl::~ArduinoRotaryEncoderInterruptControl(){}
+
+// ISR glue routines
+void ArduinoRotaryEncoderInterruptControl::handleInterruptEncoder0 ()
+{
+  instance0_->handleInterrupt ();
+}
+
+// for use by ISR glue routines
+ArduinoRotaryEncoderInterruptControl * ArduinoRotaryEncoderInterruptControl::instance0_;
+
+
+// class instance to handle an interrupt
+void ArduinoRotaryEncoderInterruptControl::handleInterrupt ()
+{
+  unsigned char encoderUp;
+  unsigned char encoderDn;
+
+  encoderUp = _digitalRead(this->Pin1) == HIGH ? 1 : 0;
+  encoderDn = _digitalRead(this->Pin2) == HIGH ? 2 : 0;
+
+  if( encoderUp != this->lastUpStatus ) {
+    if( encoderUp ) {
+    // rising edge
+      if ( encoderDn ) {
+        if( this->currentValue < this->maxValue ) this->currentValue ++;
+      } else {
+        if(this->currentValue > -this->maxValue ) this->currentValue --;
+      }
+    } else {
+    // falling edge
+      if ( encoderDn ) {
+        if( this->currentValue > -this->maxValue ) this->currentValue --;
+      } else {
+        if( this->currentValue < this->maxValue ) this->currentValue ++;
+      }
+    }
+  }
+  if (this->currentValue > this->maxValue) this->currentValue = this->maxValue;
+  if (this->currentValue < -this->maxValue) this->currentValue = -this->maxValue;
+  this->lastUpStatus = encoderUp;
+  this->isStatusChanged = true;
+}
+
+
+void ArduinoRotaryEncoderInterruptControl::setValue(int16_t value) {
+  this->currentValue = value;
+}
+
+
+float ArduinoRotaryEncoderInterruptControl::getValue(){ //returns the current value
+  float extValue;
+  /*
+  Serial.print("currentValue : ");
+  Serial.println(this->currentValue);
+  Serial.print("extValue : ");
+  Serial.println(extValue);
+  */
+  extValue = ((float)this->currentValue/this->maxValue);
+
+  return extValue;
+}
+
+bool ArduinoRotaryEncoderInterruptControl::ReadInput(){ // returns true if there was a change since the last time it was called
+
+   
+    Serial.print("Control Debug : Read ArduinoRotaryEncoderInterruptControl[");
+    Serial.print(this->Pin1);
+    Serial.print(",");
+    Serial.print(this->Pin2);
+    Serial.print("] Max Value : ");
+    Serial.print(this->maxValue);
+    Serial.print(" Stat : ");
+
+    Serial.println(this->currentValue);
+
+    // Serial.print(isStatusChanged ? "CHANGE !" : "NO CHANGE");
+    // Serial.print(", Value : ");
+    // Serial.print(this->LastPinStatus[ROTARY_ENC_OLD_STATUS_INDEX]);
+    // Serial.print(",");
+    // Serial.print(newVal);
+    // Serial.println(".");
+
+    if( this->isStatusChanged)
+    {
+      this->isStatusChanged = false;
+      return true;
+    }
+    return false;
+}

--- a/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.h
+++ b/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.h
@@ -14,38 +14,51 @@
 #define ROTARY_ENC_CUR_STATUS_INDEX 0
 #define ROTARY_ENC_OLD_STATUS_INDEX 1
 
+#define MAX_ENCODERS 2 // lower this value to save memory
 
-#define MAX_ENCODERS 2 //lower this value to save memory
+// Allows use of rotary encoder
+class ArduinoRotaryEncoderInterruptControl : public ArduinoInputControl {
 
+public:
+  static void handleInterruptEncoder0();
+  static void handleInterruptEncoder1();
+  // static void handleInterruptEncoder2 ();
+  // static void handleInterruptEncoder3 ();
+  static ArduinoRotaryEncoderInterruptControl *instance0_;
+  static ArduinoRotaryEncoderInterruptControl *instance1_;
+  // static ArduinoRotaryEncoderInterruptControl * instance2_;
+  // static ArduinoRotaryEncoderInterruptControl * instance3_;
 
-//Allows use of rotary encoder
-class ArduinoRotaryEncoderInterruptControl : public ArduinoInputControl{
+private:
+  volatile uint8_t Pin1;
+  volatile uint8_t Pin2;
+  volatile uint8_t encoderNumber;
+  volatile unsigned char lastUpStatus;
+  volatile bool isStatusChanged;
+  volatile int currentValue; // ranges from -maxValue to +maxValue with 0 being
+                             // the starting point
+  int maxValue;
+  void handleInterrupt();
 
-  public :
-    static void handleInterruptEncoder0 ();
-    static ArduinoRotaryEncoderInterruptControl * instance0_;
-    //static void handleInterruptEncoder1 ();
-
-    private :
-      volatile uint8_t Pin1;
-      volatile uint8_t Pin2;
-      volatile uint8_t encoderNumber;
-      volatile unsigned char lastUpStatus;
-      volatile bool isStatusChanged;
-      volatile int currentValue; //ranges from -maxValue to +maxValue with 0 being the starting point
-      volatile int maxValue;
-      void handleInterrupt();
-
-    public :
+public:
 #ifdef ACTIVE_MULTI_ARDUINO_BOARD_MODE
-        ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false, int boardAddress = -1);
+  ArduinoRotaryEncoderInterruptControl(uint8_t encoderNumber, uint8_t pin1,
+                                       uint8_t pin2,
+                                       uint8_t resolution_ppr = 128,
+                                       uint8_t turns = 4,
+                                       bool usePullUpPin = false,
+                                       int boardAddress = -1);
 #else
-        ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false);
+  ArduinoRotaryEncoderInterruptControl(uint8_t encoderNumber, uint8_t pin1,
+                                       uint8_t pin2,
+                                       uint8_t resolution_ppr = 128,
+                                       uint8_t turns = 4,
+                                       bool usePullUpPin = false);
 #endif
-        ~ArduinoRotaryEncoderInterruptControl();
-        bool ReadInput();
-        float getValue();
-        void setValue(int value);
+  ~ArduinoRotaryEncoderInterruptControl();
+  bool ReadInput();
+  float getValue();
+  void setValue(int value);
 };
 
 #endif // ARDUINOROTARYENCODEINTERRUPTCLASS_H_INCLUDED

--- a/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.h
+++ b/lib/ArduinoControl/ArduinoRotaryEncoderInterruptControl.h
@@ -1,0 +1,51 @@
+/**
+ * Romgere Cockpit Library - https://github.com/romgere/romgere_cockpit
+ * @author jerome@mestres.fr
+ */
+
+#ifndef ARDUINOROTARYENCODEINTERRUPTCLASS_H_INCLUDED
+#define ARDUINOROTARYENCODEINTERRUPTCLASS_H_INCLUDED
+
+#include <Arduino.h>
+
+#include "../Config/MainConfig.h"
+#include "ArduinoControl.h"
+
+#define ROTARY_ENC_CUR_STATUS_INDEX 0
+#define ROTARY_ENC_OLD_STATUS_INDEX 1
+
+
+#define MAX_ENCODERS 2 //lower this value to save memory
+
+
+//Allows use of rotary encoder
+class ArduinoRotaryEncoderInterruptControl : public ArduinoInputControl{
+
+  public :
+    static void handleInterruptEncoder0 ();
+    static ArduinoRotaryEncoderInterruptControl * instance0_;
+    //static void handleInterruptEncoder1 ();
+
+    private :
+      volatile uint8_t Pin1;
+      volatile uint8_t Pin2;
+      volatile uint8_t encoderNumber;
+      volatile unsigned char lastUpStatus;
+      volatile bool isStatusChanged;
+      volatile int currentValue; //ranges from -maxValue to +maxValue with 0 being the starting point
+      volatile int maxValue;
+      void handleInterrupt();
+
+    public :
+#ifdef ACTIVE_MULTI_ARDUINO_BOARD_MODE
+        ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false, int boardAddress = -1);
+#else
+        ArduinoRotaryEncoderInterruptControl( uint8_t encoderNumber, uint8_t pin1, uint8_t pin2, uint8_t resolution_ppr = 128, uint8_t turns = 4, bool usePullUpPin = false);
+#endif
+        ~ArduinoRotaryEncoderInterruptControl();
+        bool ReadInput();
+        float getValue();
+        void setValue(int value);
+};
+
+#endif // ARDUINOROTARYENCODEINTERRUPTCLASS_H_INCLUDED

--- a/lib/CommunicationInterface/EthernetInterface.cpp
+++ b/lib/CommunicationInterface/EthernetInterface.cpp
@@ -3,207 +3,298 @@
  * @author jerome@mestres.fr
  */
 
+
+
 #include "EthernetInterface.h"
 
-EthernetInterface::EthernetInterface(unsigned int readPort,
-                                     unsigned int writePort,
-                                     IPAddress arduinoIP, uint8_t arduinoMAC[6],
-                                     IPAddress xplaneIP, bool waitForXPlane) {
+#define DEBUG_ETHERNET true
 
-  this->IsClassInit = false;
+#define UDP_TX_DREF_LENGTH 496
+#define UDP_TX_PACKET_MAX_SIZE 509
+#define XPLANE_DREF_UDP_PACKET_SIZE 509
 
-  for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
-    this->LastXPlaneDatas[i] = NULL;
-  }
+EthernetInterface::EthernetInterface(unsigned int readPort, unsigned int writePort, IPAddress arduinoIP, uint8_t arduinoMAC[6], IPAddress xplaneIP, bool waitForXPlane) {
+    this->IsClassInit  = false;
 
-  this->XPlaneWritePort = writePort;
-  this->XplaneReadPort = readPort;
-  this->IsXPlaneAdressInit = false;
-
-  // DHCP : Unknow adress on board initialisation
-  if (xplaneIP[0] == 0)
-    XPlaneAdress = INADDR_NONE;
-  else {
-    XPlaneAdress = xplaneIP;
-    IsXPlaneAdressInit = true;
-  }
-
-  int res = 0;
-
-  // DHCP
-  if (arduinoIP[0] == 0) {
-
-    res = Ethernet.begin(arduinoMAC);
-
-    // DHCP error ! Can't do any other util stuff
-    if (res == 0) {
-      for (;;) {
-      }
-    }
-  }
-  // Fixed IP
-  else {
-    Ethernet.begin(arduinoMAC, arduinoIP);
-  }
-
-  // Start listening on UDP
-  res = this->Udp.begin(this->XplaneReadPort);
-
-  // UDP error ! Can't do any other util stuff
-  if (res == 0) {
-    for (;;) {
-    }
-  }
-  this->IsClassInit = true;
-
-  // Wait for a first exchange with X-Plane
-  if (waitForXPlane) {
-
-    while (!this->IsXPlaneAdressInit) {
-      this->ReadAllInput();
-
-      if (!this->IsXPlaneAdressInit)
-        delay(250);
-    }
-  }
-}
-
-EthernetInterface::~EthernetInterface() {}
-
-// Read and parse datas received from X-Plane. Return : Number of packet read
-// from x-Plane ()
-uint8_t EthernetInterface::ReadAllInput() {
-
-  // Pas initialisée
-  if (!this->IsClassInit)
-    return 0;
-
-  int readSize = this->Udp.parsePacket();
-  if (readSize) {
-
-    // First reception : keep X-Plane remote address
-    if (!this->IsXPlaneAdressInit) {
-      this->XPlaneAdress = this->Udp.remoteIP();
-      this->IsXPlaneAdressInit = true;
-    }
-
-    byte buffer[readSize];
-    this->Udp.read(buffer, readSize);
-
-    // Dats from X-Plane start with "DATA>"
-    // ref : http://svglobe.com/arduino/udpdata.html
-    if (buffer[0] == 'D' && buffer[1] == 'A' && buffer[2] == 'T' &&
-        buffer[3] == 'A') {
-
-      // Reset previous datas
-      for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
-        if (this->LastXPlaneDatas[i] != NULL) {
-          delete this->LastXPlaneDatas[i];
-        }
-
+    for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
         this->LastXPlaneDatas[i] = NULL;
+    }
+
+    this->XPlaneWritePort = writePort;
+    this->XplaneReadPort = readPort;
+    this->IsXPlaneAdressInit = false;
+
+    //DHCP : Unknow adress on board initialisation
+    if( xplaneIP[0] == 0)
+        XPlaneAdress = INADDR_NONE;
+    else{
+        XPlaneAdress = xplaneIP;
+        IsXPlaneAdressInit = true;
+    }
+
+    int res = 0;
+
+    //DHCP
+	  if ( arduinoIP[0] == 0){
+
+        res = Ethernet.begin(arduinoMAC);
+
+        //DHCP error ! Can't do any other util stuff
+        if( res == 0 ){
+            for(;;){}
+        }
+    }
+    //Fixed IP
+	  else{
+        Ethernet.begin( arduinoMAC, arduinoIP);
+    }
+
+#ifdef DEBUG_ETHERNET
+  if (Ethernet.hardwareStatus() == EthernetNoHardware) {
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    while (true) {
+      delay(1); // do nothing, no point running without Ethernet hardware
+    }
+  }
+#endif
+
+#ifdef DEBUG_ETHERNET
+    while (Ethernet.linkStatus() == LinkOFF) {
+      Serial.println("Ethernet cable is not connected.");
+      delay(100);
+    }
+#endif
+
+    //Start listening on UDP
+    res = this->Udp.begin( this->XplaneReadPort);
+
+
+    //UDP error ! Can't do any other util stuff
+    if( res == 0 ){
+        for(;;){}
+    }
+    this->IsClassInit = true;
+
+    //Wait for a first exchange with X-Plane
+    if ( waitForXPlane ){
+
+
+        while ( !this->IsXPlaneAdressInit ){
+            this->ReadAllInput();
+
+            if( !this->IsXPlaneAdressInit )
+                delay(250);
+        }
+	}
+
+    Serial.println("EthernetInterface init complete");
+}
+
+EthernetInterface::~EthernetInterface(){}
+
+//Read and parse datas received from X-Plane. Return : Number of packet read from x-Plane ()
+uint8_t EthernetInterface::ReadAllInput(){
+
+//char packetBuffer[UDP_TX_PACKET_MAX_SIZE];
+
+#ifdef DEBUG_ETHERNET
+  Serial.println("ReadAllInput");
+#endif
+
+    //Pas initialisée
+    if( ! this->IsClassInit )
+        return 0;
+
+    int readSize = this->Udp.parsePacket();
+      if (readSize){
+
+#ifdef DEBUG_ETHERNET
+    Serial.print("Received UDP packet of size ");
+    Serial.println(readSize);
+
+    Serial.print("From ");
+    IPAddress remote = this->Udp.remoteIP();
+    for (int i=0; i < 4; i++) {
+      Serial.print(remote[i], DEC);
+      if (i < 3) {
+        Serial.print(".");
       }
-
-      uint8_t index = 0;
-      // Parse received data (By 36 Bytes packet, length of X-Plane data )
-      for (int i = 5; i < readSize; i += 36) {
-
-        XPGroupDatas *p = new XPGroupDatas();
-        // First byte : Data's group
-        p->group = buffer[i];
-
-        // Datas : table of 8 float value (8 x 4 bytes)
-        for (int j = 0; j < 8; j++) {
-
-          XPNetworkData tmpData;
-
-          for (int k = 0; k < 4; k++) {
-            tmpData.byteVal[k] = buffer[i + 4 + (j * 4) + k];
-          }
-          // Convert 4 byte array to float with XPNetworkData union
-          p->data[j] = tmpData.floatVal;
+    }
+    Serial.print(", port ");
+    Serial.println(this->Udp.remotePort());
+#endif
+        //First reception : keep X-Plane remote address
+        if ( !this->IsXPlaneAdressInit ){
+            this->XPlaneAdress = this->Udp.remoteIP();
+            this->IsXPlaneAdressInit = true;
         }
 
-        this->LastXPlaneDatas[index] = p;
 
-        index++;
+        byte buffer[readSize];
+        this->Udp.read( buffer, readSize );
+
+#ifdef DEBUG_ETHERNET
+  Serial.print("Udp.read: ");
+  Serial.println(buffer[0]);
+#endif
+        //Dats from X-Plane start with "DATA>"
+        //ref : http://svglobe.com/arduino/udpdata.html
+        if (buffer[0] == 'D' && buffer[1] == 'A' && buffer[2] == 'T' && buffer[3] == 'A'  ){
+
+            //Reset previous datas
+            for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
+                if( this->LastXPlaneDatas[i] != NULL ){
+                    delete this->LastXPlaneDatas[i];
+                }
+
+                this->LastXPlaneDatas[i] = NULL;
+            }
+
+
+            uint8_t index = 0;
+            //Parse received data (By 36 Bytes packet, length of X-Plane data )
+            for (int i=5 ; i < readSize; i+=36) {
+
+Serial.println("Here1");
+                XPGroupDatas *p = new XPGroupDatas();
+Serial.println("Here2");
+
+                //First byte : Data's group
+                p->group = buffer[i];
+
+#ifdef DEBUG_ETHERNET
+                Serial.print("Ethernet debug : Receive data for group ");
+                Serial.print(p->group);
+                Serial.print(" with value [");
+#endif
+
+                //Datas : table of 8 float value (8 x 4 bytes)
+                for (int j=0; j<8; j++){
+
+                    XPNetworkData tmpData;
+
+                    for (int k=0; k<4; k++){
+                        tmpData.byteVal[k] = buffer[i + 4 + (j*4) + k];
+                    }
+                    //Convert 4 byte array to float with XPNetworkData union
+                    p->data[j] = tmpData.floatVal;
+#ifdef DEBUG_ETHERNET
+                    Serial.print(p->data[j]);
+                    Serial.print(",");
+#endif
+                }
+
+#ifdef DEBUG_ETHERNET
+                Serial.println("].");
+#endif
+                this->LastXPlaneDatas[index] = p;
+
+                index++;
+            }
+
+            //Return the number of data group read (if 0 no output will be modified)
+            return index;
+
+        }
+
+#ifdef DEBUG_ETHERNET
+        Serial.println("Ethernet debug : Data received not start with \"DATA>\" : ");
+        Serial.println("---------------START------------------");
+        for (int i=0; i < readSize; i++)
+            Serial.print((char)buffer[i]);
+        Serial.println("----------------END-------------------");
+#endif
+	  }
+
+	  return 0;
+}
+
+
+
+//Send a key to X-Plane
+void EthernetInterface::SendKey( const char* key) {
+
+    if( ! this->IsClassInit )
+        return;
+
+    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
+    this->Udp.write("CHAR0");
+    this->Udp.write((char)*key);
+    this->Udp.write("");
+    this->Udp.endPacket();
+}
+
+
+//Send command to X-Plane
+void EthernetInterface::SendCommand( const char* cmd) {
+
+    if( ! this->IsClassInit )
+        return;
+
+    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
+    this->Udp.write("CMND0");
+	  this->Udp.write(cmd) ;
+    this->Udp.endPacket();
+}
+
+
+void EthernetInterface::SendDrefCommand( const char *dref, float value){
+
+    if( ! this->IsClassInit )
+        return;
+
+    char DataOut[XPLANE_DREF_UDP_PACKET_SIZE + 1];
+    char drefLabel[] = "DREF";
+
+    XPNetworkData tmpData;
+    tmpData.floatVal = value;
+
+    strcpy(DataOut, drefLabel);
+    DataOut[4] = 0; //zero terminate label
+
+    for (int copyCounter = 0; copyCounter<4; copyCounter++) { //4 bytes of float value
+      DataOut[5 + copyCounter] = tmpData.byteVal[copyCounter];
+    }
+    
+    strcpy( &DataOut[9], "sim/");
+    strcpy( &DataOut[13], dref);
+
+    int drefTerminationPoint = strlen(dref) + 13;
+    DataOut[drefTerminationPoint] = 0; //terminate dref_path value with 0
+    memset(&DataOut[drefTerminationPoint + 1], char(32), XPLANE_DREF_UDP_PACKET_SIZE - drefTerminationPoint);
+
+    DataOut[XPLANE_DREF_UDP_PACKET_SIZE - 1] = 0;
+
+#ifdef DEBUG_ETHERNET
+    Serial.print("Send DREF command: ");
+    for (int k=0;k<UDP_TX_DREF_LENGTH;k++)
+    {
+      if (isPrintable(DataOut[k]))
+      {
+        Serial.print(DataOut[k]);
       }
-
-      // Return the number of data group read (if 0 no output will be modified)
-      return index;
+      else
+      {
+        Serial.print("\\0x");
+        Serial.print(DataOut[k], HEX);
+      }
     }
-  }
+    Serial.println("<END>");
+#endif
 
-  return 0;
+    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
+    this->Udp.write(DataOut, XPLANE_DREF_UDP_PACKET_SIZE);
+    this->Udp.endPacket();
 }
 
-// Send a key to X-Plane
-void EthernetInterface::SendKey(const char *key) {
+//Get a datas received for a given group number
+XPGroupDatas* EthernetInterface::GetData( float group ){
 
-  if (!this->IsClassInit)
-    return;
-
-  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
-  this->Udp.write("CHAR0");
-  this->Udp.write((char)*key);
-  this->Udp.write("");
-  this->Udp.endPacket();
-}
-
-// Send command to X-Plane
-void EthernetInterface::SendCommand(const char *cmd) {
-
-  if (!this->IsClassInit)
-    return;
-
-  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
-  this->Udp.write("CMND0");
-  this->Udp.write(cmd);
-  this->Udp.endPacket();
-}
-
-// Send DREF command to X-Plane
-void EthernetInterface::SendDrefCommand(const char *dref, float value) {
-
-  if (!this->IsClassInit)
-    return;
-
-  // Convert DREF value
-  XPNetworkData tmpData;
-  tmpData.floatVal = value;
-
-  // build DREF name
-  char DataOut[497];
-  int i = 0;
-  while (dref[i] != 0 && i < 496) {
-    DataOut[i] = dref[i];
-    i++;
-  }
-  for (; i < 496; i++) {
-    DataOut[i] = char(32);
-  }
-  DataOut[i] = 0;
-
-  // Send datas
-  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
-  this->Udp.write("DREF0");
-  for (int i = 0; i < 4; i++) {
-    this->Udp.write(tmpData.byteVal[i]);
-  }
-  this->Udp.write("sim/");
-  this->Udp.write(DataOut);
-  this->Udp.endPacket();
-}
-
-// Get a datas received for a given group number
-XPGroupDatas *EthernetInterface::GetData(float group) {
-
-  for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
-    if (this->LastXPlaneDatas[i] != NULL &&
-        this->LastXPlaneDatas[i]->group == group) {
-      return this->LastXPlaneDatas[i];
+    for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
+        if( this->LastXPlaneDatas[i] != NULL &&  this->LastXPlaneDatas[i]->group == group ){
+            return this->LastXPlaneDatas[i];
+        }
     }
-  }
 
-  return NULL;
+    return NULL;
 }

--- a/lib/CommunicationInterface/EthernetInterface.cpp
+++ b/lib/CommunicationInterface/EthernetInterface.cpp
@@ -3,55 +3,56 @@
  * @author jerome@mestres.fr
  */
 
-
-
 #include "EthernetInterface.h"
 
-#define DEBUG_ETHERNET true
+// #define DEBUG_ETHERNET
 
-#define UDP_TX_DREF_LENGTH 496
-#define UDP_TX_PACKET_MAX_SIZE 509
 #define XPLANE_DREF_UDP_PACKET_SIZE 509
 
-EthernetInterface::EthernetInterface(unsigned int readPort, unsigned int writePort, IPAddress arduinoIP, uint8_t arduinoMAC[6], IPAddress xplaneIP, bool waitForXPlane) {
-    this->IsClassInit  = false;
+EthernetInterface::EthernetInterface(unsigned int readPort,
+                                     unsigned int writePort,
+                                     IPAddress arduinoIP, uint8_t arduinoMAC[6],
+                                     IPAddress xplaneIP, bool waitForXPlane) {
+  this->IsClassInit = false;
 
-    for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
-        this->LastXPlaneDatas[i] = NULL;
+  for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
+    this->LastXPlaneDatas[i] = NULL;
+  }
+
+  this->XPlaneWritePort = writePort;
+  this->XplaneReadPort = readPort;
+  this->IsXPlaneAdressInit = false;
+
+  // DHCP : Unknow adress on board initialisation
+  if (xplaneIP[0] == 0)
+    XPlaneAdress = INADDR_NONE;
+  else {
+    XPlaneAdress = xplaneIP;
+    IsXPlaneAdressInit = true;
+  }
+
+  int res = 0;
+
+  // DHCP
+  if (arduinoIP[0] == 0) {
+
+    res = Ethernet.begin(arduinoMAC);
+
+    // DHCP error ! Can't do any other util stuff
+    if (res == 0) {
+      for (;;) {
+      }
     }
-
-    this->XPlaneWritePort = writePort;
-    this->XplaneReadPort = readPort;
-    this->IsXPlaneAdressInit = false;
-
-    //DHCP : Unknow adress on board initialisation
-    if( xplaneIP[0] == 0)
-        XPlaneAdress = INADDR_NONE;
-    else{
-        XPlaneAdress = xplaneIP;
-        IsXPlaneAdressInit = true;
-    }
-
-    int res = 0;
-
-    //DHCP
-	  if ( arduinoIP[0] == 0){
-
-        res = Ethernet.begin(arduinoMAC);
-
-        //DHCP error ! Can't do any other util stuff
-        if( res == 0 ){
-            for(;;){}
-        }
-    }
-    //Fixed IP
-	  else{
-        Ethernet.begin( arduinoMAC, arduinoIP);
-    }
+  }
+  // Fixed IP
+  else {
+    Ethernet.begin(arduinoMAC, arduinoIP);
+  }
 
 #ifdef DEBUG_ETHERNET
   if (Ethernet.hardwareStatus() == EthernetNoHardware) {
-    Serial.println("Ethernet shield was not found.  Sorry, can't run without hardware. :(");
+    Serial.println("Ethernet shield was not found.  Sorry, can't run without "
+                   "hardware. :(");
     while (true) {
       delay(1); // do nothing, no point running without Ethernet hardware
     }
@@ -59,54 +60,52 @@ EthernetInterface::EthernetInterface(unsigned int readPort, unsigned int writePo
 #endif
 
 #ifdef DEBUG_ETHERNET
-    while (Ethernet.linkStatus() == LinkOFF) {
-      Serial.println("Ethernet cable is not connected.");
-      delay(100);
-    }
+  while (Ethernet.linkStatus() == LinkOFF) {
+    Serial.println("Ethernet cable is not connected.");
+    delay(100);
+  }
 #endif
 
-    //Start listening on UDP
-    res = this->Udp.begin( this->XplaneReadPort);
+  // Start listening on UDP
+  res = this->Udp.begin(this->XplaneReadPort);
 
-
-    //UDP error ! Can't do any other util stuff
-    if( res == 0 ){
-        for(;;){}
+  // UDP error ! Can't do any other util stuff
+  if (res == 0) {
+    for (;;) {
     }
-    this->IsClassInit = true;
+  }
+  this->IsClassInit = true;
 
-    //Wait for a first exchange with X-Plane
-    if ( waitForXPlane ){
+  // Wait for a first exchange with X-Plane
+  if (waitForXPlane) {
 
+    while (!this->IsXPlaneAdressInit) {
+      this->ReadAllInput();
 
-        while ( !this->IsXPlaneAdressInit ){
-            this->ReadAllInput();
+      if (!this->IsXPlaneAdressInit)
+        delay(250);
+    }
+  }
 
-            if( !this->IsXPlaneAdressInit )
-                delay(250);
-        }
-	}
-
-    Serial.println("EthernetInterface init complete");
+  Serial.println("EthernetInterface init complete");
 }
 
-EthernetInterface::~EthernetInterface(){}
+EthernetInterface::~EthernetInterface() {}
 
-//Read and parse datas received from X-Plane. Return : Number of packet read from x-Plane ()
-uint8_t EthernetInterface::ReadAllInput(){
-
-//char packetBuffer[UDP_TX_PACKET_MAX_SIZE];
+// Read and parse datas received from X-Plane. Return : Number of packet read
+// from x-Plane ()
+uint8_t EthernetInterface::ReadAllInput() {
 
 #ifdef DEBUG_ETHERNET
   Serial.println("ReadAllInput");
 #endif
 
-    //Pas initialisée
-    if( ! this->IsClassInit )
-        return 0;
+  // Pas initialisée
+  if (!this->IsClassInit)
+    return 0;
 
-    int readSize = this->Udp.parsePacket();
-      if (readSize){
+  int readSize = this->Udp.parsePacket();
+  if (readSize) {
 
 #ifdef DEBUG_ETHERNET
     Serial.print("Received UDP packet of size ");
@@ -114,7 +113,7 @@ uint8_t EthernetInterface::ReadAllInput(){
 
     Serial.print("From ");
     IPAddress remote = this->Udp.remoteIP();
-    for (int i=0; i < 4; i++) {
+    for (int i = 0; i < 4; i++) {
       Serial.print(remote[i], DEC);
       if (i < 3) {
         Serial.print(".");
@@ -123,178 +122,173 @@ uint8_t EthernetInterface::ReadAllInput(){
     Serial.print(", port ");
     Serial.println(this->Udp.remotePort());
 #endif
-        //First reception : keep X-Plane remote address
-        if ( !this->IsXPlaneAdressInit ){
-            this->XPlaneAdress = this->Udp.remoteIP();
-            this->IsXPlaneAdressInit = true;
-        }
-
-
-        byte buffer[readSize];
-        this->Udp.read( buffer, readSize );
-
-#ifdef DEBUG_ETHERNET
-  Serial.print("Udp.read: ");
-  Serial.println(buffer[0]);
-#endif
-        //Dats from X-Plane start with "DATA>"
-        //ref : http://svglobe.com/arduino/udpdata.html
-        if (buffer[0] == 'D' && buffer[1] == 'A' && buffer[2] == 'T' && buffer[3] == 'A'  ){
-
-            //Reset previous datas
-            for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
-                if( this->LastXPlaneDatas[i] != NULL ){
-                    delete this->LastXPlaneDatas[i];
-                }
-
-                this->LastXPlaneDatas[i] = NULL;
-            }
-
-
-            uint8_t index = 0;
-            //Parse received data (By 36 Bytes packet, length of X-Plane data )
-            for (int i=5 ; i < readSize; i+=36) {
-
-Serial.println("Here1");
-                XPGroupDatas *p = new XPGroupDatas();
-Serial.println("Here2");
-
-                //First byte : Data's group
-                p->group = buffer[i];
-
-#ifdef DEBUG_ETHERNET
-                Serial.print("Ethernet debug : Receive data for group ");
-                Serial.print(p->group);
-                Serial.print(" with value [");
-#endif
-
-                //Datas : table of 8 float value (8 x 4 bytes)
-                for (int j=0; j<8; j++){
-
-                    XPNetworkData tmpData;
-
-                    for (int k=0; k<4; k++){
-                        tmpData.byteVal[k] = buffer[i + 4 + (j*4) + k];
-                    }
-                    //Convert 4 byte array to float with XPNetworkData union
-                    p->data[j] = tmpData.floatVal;
-#ifdef DEBUG_ETHERNET
-                    Serial.print(p->data[j]);
-                    Serial.print(",");
-#endif
-                }
-
-#ifdef DEBUG_ETHERNET
-                Serial.println("].");
-#endif
-                this->LastXPlaneDatas[index] = p;
-
-                index++;
-            }
-
-            //Return the number of data group read (if 0 no output will be modified)
-            return index;
-
-        }
-
-#ifdef DEBUG_ETHERNET
-        Serial.println("Ethernet debug : Data received not start with \"DATA>\" : ");
-        Serial.println("---------------START------------------");
-        for (int i=0; i < readSize; i++)
-            Serial.print((char)buffer[i]);
-        Serial.println("----------------END-------------------");
-#endif
-	  }
-
-	  return 0;
-}
-
-
-
-//Send a key to X-Plane
-void EthernetInterface::SendKey( const char* key) {
-
-    if( ! this->IsClassInit )
-        return;
-
-    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
-    this->Udp.write("CHAR0");
-    this->Udp.write((char)*key);
-    this->Udp.write("");
-    this->Udp.endPacket();
-}
-
-
-//Send command to X-Plane
-void EthernetInterface::SendCommand( const char* cmd) {
-
-    if( ! this->IsClassInit )
-        return;
-
-    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
-    this->Udp.write("CMND0");
-	  this->Udp.write(cmd) ;
-    this->Udp.endPacket();
-}
-
-
-void EthernetInterface::SendDrefCommand( const char *dref, float value){
-
-    if( ! this->IsClassInit )
-        return;
-
-    char DataOut[XPLANE_DREF_UDP_PACKET_SIZE + 1];
-    char drefLabel[] = "DREF";
-
-    XPNetworkData tmpData;
-    tmpData.floatVal = value;
-
-    strcpy(DataOut, drefLabel);
-    DataOut[4] = 0; //zero terminate label
-
-    for (int copyCounter = 0; copyCounter<4; copyCounter++) { //4 bytes of float value
-      DataOut[5 + copyCounter] = tmpData.byteVal[copyCounter];
+    // First reception : keep X-Plane remote address
+    if (!this->IsXPlaneAdressInit) {
+      this->XPlaneAdress = this->Udp.remoteIP();
+      this->IsXPlaneAdressInit = true;
     }
-    
-    strcpy( &DataOut[9], "sim/");
-    strcpy( &DataOut[13], dref);
 
-    int drefTerminationPoint = strlen(dref) + 13;
-    DataOut[drefTerminationPoint] = 0; //terminate dref_path value with 0
-    memset(&DataOut[drefTerminationPoint + 1], char(32), XPLANE_DREF_UDP_PACKET_SIZE - drefTerminationPoint);
-
-    DataOut[XPLANE_DREF_UDP_PACKET_SIZE - 1] = 0;
+    byte buffer[readSize];
+    this->Udp.read(buffer, readSize);
 
 #ifdef DEBUG_ETHERNET
-    Serial.print("Send DREF command: ");
-    for (int k=0;k<UDP_TX_DREF_LENGTH;k++)
-    {
-      if (isPrintable(DataOut[k]))
-      {
+    Serial.print("Udp.read: ");
+    Serial.println(buffer[0]);
+#endif
+    // Dats from X-Plane start with "DATA>"
+    // ref : http://svglobe.com/arduino/udpdata.html
+    if (buffer[0] == 'D' && buffer[1] == 'A' && buffer[2] == 'T' &&
+        buffer[3] == 'A') {
+
+      // Reset previous datas
+      for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
+        if (this->LastXPlaneDatas[i] != NULL) {
+          delete this->LastXPlaneDatas[i];
+        }
+
+        this->LastXPlaneDatas[i] = NULL;
+      }
+
+      uint8_t index = 0;
+      // Parse received data (By 36 Bytes packet, length of X-Plane data )
+      for (int i = 5; i < readSize; i += 36) {
+
+        Serial.println("Here1");
+        XPGroupDatas *p = new XPGroupDatas();
+        Serial.println("Here2");
+
+        // First byte : Data's group
+        p->group = buffer[i];
+
+#ifdef DEBUG_ETHERNET
+        Serial.print("Ethernet debug : Receive data for group ");
+        Serial.print(p->group);
+        Serial.print(" with value [");
+#endif
+
+        // Datas : table of 8 float value (8 x 4 bytes)
+        for (int j = 0; j < 8; j++) {
+
+          XPNetworkData tmpData;
+
+          for (int k = 0; k < 4; k++) {
+            tmpData.byteVal[k] = buffer[i + 4 + (j * 4) + k];
+          }
+          // Convert 4 byte array to float with XPNetworkData union
+          p->data[j] = tmpData.floatVal;
+#ifdef DEBUG_ETHERNET
+          Serial.print(p->data[j]);
+          Serial.print(",");
+#endif
+        }
+
+#ifdef DEBUG_ETHERNET
+        Serial.println("].");
+#endif
+        this->LastXPlaneDatas[index] = p;
+
+        index++;
+      }
+
+      // Return the number of data group read (if 0 no output will be modified)
+      return index;
+    }
+
+#ifdef DEBUG_ETHERNET
+    Serial.println(
+        "Ethernet debug : Data received not start with \"DATA>\" : ");
+    Serial.println("---------------START------------------");
+    for (int i = 0; i < readSize; i++)
+      Serial.print((char)buffer[i]);
+    Serial.println("----------------END-------------------");
+#endif
+  }
+
+  return 0;
+}
+
+// Send a key to X-Plane
+void EthernetInterface::SendKey(const char *key) {
+
+  if (!this->IsClassInit)
+    return;
+
+  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
+  this->Udp.write("CHAR0");
+  this->Udp.write((char)*key);
+  this->Udp.write("");
+  this->Udp.endPacket();
+}
+
+// Send command to X-Plane
+void EthernetInterface::SendCommand(const char *cmd) {
+
+  if (!this->IsClassInit)
+    return;
+
+  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
+  this->Udp.write("CMND0");
+  this->Udp.write(cmd);
+  this->Udp.endPacket();
+}
+
+void EthernetInterface::SendDrefCommand(const char *dref, float value) {
+
+  if (!this->IsClassInit)
+    return;
+
+  char DataOut[XPLANE_DREF_UDP_PACKET_SIZE + 1];
+
+  XPNetworkData tmpData;
+  tmpData.floatVal = value;
+
+  strcpy(DataOut, "DREF");
+  DataOut[4] = 0; // zero terminate label
+
+  for (int copyCounter = 0; copyCounter < 4;
+       copyCounter++) { // 4 bytes of float value
+    DataOut[5 + copyCounter] = tmpData.byteVal[copyCounter];
+  }
+
+  strcpy(&DataOut[9], "sim/");
+  strcpy(&DataOut[13], dref);
+
+  int drefTerminationPoint = strlen(dref) + 13;
+  DataOut[drefTerminationPoint] = 0; // terminate dref_path value with 0
+  memset(&DataOut[drefTerminationPoint + 1], char(32),
+         XPLANE_DREF_UDP_PACKET_SIZE - drefTerminationPoint);
+
+  DataOut[XPLANE_DREF_UDP_PACKET_SIZE - 1] = 0;
+
+#ifdef DEBUG_ETHERNET
+  Serial.print("Send DREF command: ");
+  for (int k = 0; k < XPLANE_DREF_UDP_PACKET_SIZE; k++) {
+    if (isPrintable(DataOut[k])) {
+      if (DataOut[k] != char(32)) // no need to print these
         Serial.print(DataOut[k]);
-      }
-      else
-      {
-        Serial.print("\\0x");
-        Serial.print(DataOut[k], HEX);
-      }
+    } else {
+      Serial.print("\\0x");
+      Serial.print(DataOut[k], HEX);
     }
-    Serial.println("<END>");
+  }
+  Serial.print(" value:");
+  Serial.println(value);
 #endif
 
-    this->Udp.beginPacket( this->XPlaneAdress, this->XPlaneWritePort);
-    this->Udp.write(DataOut, XPLANE_DREF_UDP_PACKET_SIZE);
-    this->Udp.endPacket();
+  this->Udp.beginPacket(this->XPlaneAdress, this->XPlaneWritePort);
+  this->Udp.write(DataOut, XPLANE_DREF_UDP_PACKET_SIZE);
+  this->Udp.endPacket();
 }
 
-//Get a datas received for a given group number
-XPGroupDatas* EthernetInterface::GetData( float group ){
+// Get a datas received for a given group number
+XPGroupDatas *EthernetInterface::GetData(float group) {
 
-    for( int i =0; i < MAX_INPUT_DATA_FROM_XPLANE; i++ ){
-        if( this->LastXPlaneDatas[i] != NULL &&  this->LastXPlaneDatas[i]->group == group ){
-            return this->LastXPlaneDatas[i];
-        }
+  for (int i = 0; i < MAX_INPUT_DATA_FROM_XPLANE; i++) {
+    if (this->LastXPlaneDatas[i] != NULL &&
+        this->LastXPlaneDatas[i]->group == group) {
+      return this->LastXPlaneDatas[i];
     }
+  }
 
-    return NULL;
+  return NULL;
 }

--- a/lib/CommunicationInterface/EthernetInterface.h
+++ b/lib/CommunicationInterface/EthernetInterface.h
@@ -11,7 +11,7 @@
 #include <EthernetENC.h>
 #else
 #include <Ethernet.h>
-
+#endif
 #include "../Config/MainConfig.h"
 #include "BaseCommunicationInterface.h"
 

--- a/lib/CommunicationInterface/EthernetInterface.h
+++ b/lib/CommunicationInterface/EthernetInterface.h
@@ -7,6 +7,9 @@
 #define XPLANENETWORKINGCLASS_H_INCLUDED
 
 #include <Arduino.h>
+#ifndef USE_ENC28J60_ETHERNET_MODULE
+#include <EthernetENC.h>
+#else
 #include <Ethernet.h>
 
 #include "../Config/MainConfig.h"

--- a/lib/Config/MainConfig.h
+++ b/lib/Config/MainConfig.h
@@ -20,28 +20,28 @@
 /*
  * Enable multiple board mode (Master and Slave(s) board with I2C communication)
  */
-//#define ACTIVE_MULTI_ARDUINO_BOARD_MODE
+// #define ACTIVE_MULTI_ARDUINO_BOARD_MODE
 
 /*
  * Max input and output controls the application can manage.
  * Decrease = Memory saving.
  */
-#define MAX_INPUT_CONTROL_IN_APPLICATION 128
-#define MAX_OUTPUT_CONTROL_IN_APPLICATION 128
+#define MAX_INPUT_CONTROL_IN_APPLICATION 32  // 128
+#define MAX_OUTPUT_CONTROL_IN_APPLICATION 32 // 128
 
 /*
  * Max number of command who can be bind to one control.
  * Min : 3 (For 3 position toggle switch)
  * Max : 10 (For rotary switch)
  */
-#define MAX_COMMAND_FOR_ONE_CONTROLE 10
+#define MAX_COMMAND_FOR_ONE_CONTROLE 5
 
 /*
  * Max input data group received from X-Plane the application can manage
  * Adapt for your need.
  * Decrease = Memory saving.
  */
-#define MAX_INPUT_DATA_FROM_XPLANE 32
+#define MAX_INPUT_DATA_FROM_XPLANE 16 // 32
 
 /*
  * Defined the frequency of read data action (from X-Plane) on "loop" method

--- a/lib/Config/MainConfig.h
+++ b/lib/Config/MainConfig.h
@@ -13,9 +13,14 @@
 #define DEBUG_SERIAL_SPEED 115200
 
 /*
+ * Use ENC28J60 chip based Ethernet module
+ */
+#define USE_ENC28J60_ETHERNET_MODULE
+
+/*
  * Enable multiple board mode (Master and Slave(s) board with I2C communication)
  */
-#define ACTIVE_MULTI_ARDUINO_BOARD_MODE
+//#define ACTIVE_MULTI_ARDUINO_BOARD_MODE
 
 /*
  * Max input and output controls the application can manage.

--- a/lib/XPlaneData/XPlaneCommand.h
+++ b/lib/XPlaneData/XPlaneCommand.h
@@ -100,8 +100,8 @@ class LibrarySpecialCommand : public XPlaneOutputCommand {
 
 public:
   typedef enum {
-    SendAll = 0, // Send all command of all (toggle switch and rotary switch)
-                 // input control even if control was not modified
+    SendAll = 0,  // Send all command of all (toggle switch and rotary switch)
+                  // input control even if control was not modified
     ResetArduino, // Reset Arduino board
     AllLedOn,     // Turn on all LED output controls (Example : testing panel)
     AllLedOff,    // Turn off all LED output controls


### PR DESCRIPTION
I had some problems with missing inputs on the stock ArduinoRotaryEncoderControl class using some high resolution rotary encoders. This new class ArduinoRotaryEncoderInterruptControl uses interrupts to make sure that no inputs are missed. 